### PR TITLE
stuff

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,8 @@ Python project to transform a csv file from XTB into a csv file that can be used
 
 ## Usage
 
-1. Enter the path **to** your csv file
-2. Enter the path for your **output** csv file
-3. The **output** csv file can be imported to **Transactions** in the **app**
+1. In terminal: `python -i {xtb_csv_path} -o {output_csv_path}`
+2. The **output** csv file can be imported to **Transactions** in the **app**
 
 ## Resources
 

--- a/main.py
+++ b/main.py
@@ -1,23 +1,27 @@
 import pandas as pd
 import os
+import argparse
 
-path_to_csv = input("Path to your csv file (without .csv): ")
-path_to_output_csv = input("Path for your output csv file (without .csv): ")
+ap = argparse.ArgumentParser()
+ap.add_argument("-i", "--input", required=True, help="Path to XTB csv file")
+ap.add_argument("-o", "--output", required=True, help="Path for your output csv file")
+args = vars(ap.parse_args())
 
-path = f"{path_to_csv}.csv"
+input_path = args["input"]
+output_path = args["output"]
 
-if os.path.exists(path):
-    data_from_xtb = pd.read_csv("../Movies/xtb.csv", usecols=["Symbol", "Comment", "Time"], sep=";")
-    data_to_app = data_from_xtb.copy()
-
-    new_columns = ["Ticker", "Quantity", "Cost Per Share", "Date"]
-    data_to_app = data_to_app.reindex(columns=new_columns)
-
-    data_to_app["Ticker"] = data_from_xtb["Symbol"].str.split(".").str[0]
-    data_to_app["Quantity"] = data_from_xtb["Comment"].str.split(" ").str[2]
-    data_to_app["Cost Per Share"] = data_from_xtb["Comment"].str.split(" ").str[4]
-    data_to_app["Date"] = pd.to_datetime(data_from_xtb["Time"].str.split(" ").str[0], dayfirst=True)
-
-    data_to_app.to_csv(f"{path_to_output_csv}.csv", index=False)
-else:
+if not os.path.exists(input_path):
     print("File does not exist")
+
+data_from_xtb = pd.read_csv(input_path, usecols=["Symbol", "Comment", "Time"], sep=";")
+data_to_app = data_from_xtb.copy()
+
+new_columns = ["Ticker", "Quantity", "Cost Per Share", "Date"]
+data_to_app = data_to_app.reindex(columns=new_columns)
+
+data_to_app["Ticker"] = data_from_xtb["Symbol"]
+data_to_app["Quantity"] = data_from_xtb["Comment"].str.split(" ").str[2].str.split("/").str[0]
+data_to_app["Cost Per Share"] = data_from_xtb["Comment"].str.split(" ").str[4]
+data_to_app["Date"] = pd.to_datetime(data_from_xtb["Time"].str.split(" ").str[0], dayfirst=True)
+
+data_to_app.to_csv(output_path, index=False, sep=";")

--- a/main.py
+++ b/main.py
@@ -11,7 +11,7 @@ input_path = args["input"]
 output_path = args["output"]
 
 if not os.path.exists(input_path):
-    print("File does not exist")
+    raise FileNotFoundError(f"File {input_path} does not exist")
 
 data_from_xtb = pd.read_csv(input_path, usecols=["Symbol", "Comment", "Time"], sep=";")
 data_to_app = data_from_xtb.copy()


### PR DESCRIPTION
I briefly updated the script for myself, but I figured I'd make a PR.
The input path was probably accidentally left hardcoded (xtb.csv is my favorite movie too). I changed the input/output path choice to args, just my preference.
I split the cost per share value by "/" since my data shows some split transactions, e.g.:
`OPEN BUY 9/9.2008 @ 538.60`
`OPEN BUY 0.2008/9.2008 @ 538.53`
Also, I kept the entire ticker value. I assume you split it by "." because a ticker from XTB had a suffix that was not available in the divtracker, e.g. INTC.US -> INTC. However, that results in e.g. SXR8.DE having only the SXR8 part, which is not in divtracker, so it makes sense to keep the full original ticker name and adjust it manually if it complains during import.